### PR TITLE
update link to function words list in docs

### DIFF
--- a/R/function_words.R
+++ b/R/function_words.R
@@ -1,7 +1,7 @@
 #' Function Words
 #'
 #' A vector of function words from
-#' \href{http://myweb.tiscali.co.uk/wordscape/museum/funcword.html}{John and Muriel Higgins's list}
+#' \href{http://www.marlodge.net/Function-words/}{John and Muriel Higgins's list}
 #' used for the text game ECLIPSE.  The list is augmented with additional
 #' contractions from \code{\link[lexicon]{key_contractions}}.
 #'
@@ -11,5 +11,5 @@
 #' @name function_words
 #' @usage data(function_words)
 #' @format A character vector with 350 elements
-#' @references \url{http://myweb.tiscali.co.uk/wordscape/museum/funcword.html}
+#' @references \url{http://www.marlodge.net/Function-words/}
 NULL


### PR DESCRIPTION
Many thanks for the package in general! I went to add a reference to  the `function_words` list in something I was working on and found that the link was now dead. I've replaced it with what _seems_ to be the right thing, though it provides the words only in caps and is missing a handful of contractions. I imagine you added those in the original processing.
This is my first pull request, I hope I am doing it right...